### PR TITLE
Fix issue in power menu (#8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightdm-neon",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lightdm-neon",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^22.0.0",
         "@rollup/plugin-node-resolve": "^13.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightdm-neon",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "build": "rollup -c",

--- a/src/pages/PowerMenu.svelte
+++ b/src/pages/PowerMenu.svelte
@@ -6,19 +6,19 @@
 <Container>
     <div class="container">
         {#if window.lightdm.can_hibernate}
-            <BigButton icon="Moon24" text="Hibernate" on:click={window.lightdm.hibernate} />
+            <BigButton icon="Moon24" text="Hibernate" on:click={() => window.lightdm.hibernate()} />
         {/if}
     
         {#if window.lightdm.can_suspend}
-            <BigButton icon="NoEntry24" text="Suspend" on:click={window.lightdm.suspend} />
+            <BigButton icon="NoEntry24" text="Suspend" on:click={() => window.lightdm.suspend()} />
         {/if}
     
         {#if window.lightdm.can_restart}
-            <BigButton icon="Sync24" text="Restart" on:click={window.lightdm.restart} />
+            <BigButton icon="Sync24" text="Restart" on:click={() => window.lightdm.restart()} />
         {/if}
     
         {#if window.lightdm.can_shutdown}
-            <BigButton icon="Plug24" text="Shutdown" on:click={window.lightdm.shutdown} />
+            <BigButton icon="Plug24" text="Shutdown" on:click={() => window.lightdm.shutdown()} />
         {/if}
     </div>
 </Container>

--- a/src/utils/mock.ts
+++ b/src/utils/mock.ts
@@ -242,15 +242,19 @@ export class Greeter implements GreeterClass {
     }
 
     hibernate() {
+        alert('hibernate');
         return true;
     }
     restart() {
+        alert('restart');
         return true;
     }
     shutdown() {
+        alert('shutdown')
         return true;
     }
     suspend() {
+        alert('suspend');
         return true;
     }
     respond(response: string) {


### PR DESCRIPTION
There was an issue on web-greeter with the power-menu.
It was probably caused by the `window.lightdm` object not being ready when the svelte powermenu was instantiated, changing the `on:click` to a function call rather than just a function reference seems to resolve the problem.

Fixes #8 