### PR TITLE
Fix to the overlapping images in the selector

### DIFF
--- a/src/pages/Backgrounds.svelte
+++ b/src/pages/Backgrounds.svelte
@@ -52,7 +52,7 @@
 
 <style>
     #backgrounds {
-        @apply flex flex-col gap-8 text-white fill-white;
+        @apply flex flex-col gap-8 text-white fill-white overflow-auto m-auto h-full;
     }
 
 	.image-group {
@@ -60,7 +60,7 @@
 	}
 
 	.image {
-		@apply w-256px h-144px hover:bg-gray-400 bg-cover bg-center border border-gray-400 bg-blend-overlay transition cursor-pointer;
+		@apply flex-grow w-256px h-144px hover:bg-gray-400 bg-cover bg-center border border-gray-400 bg-blend-overlay transition cursor-pointer;
         background-image: var(--bg-image);
 	}
 </style>


### PR DESCRIPTION
This is a fix to the overlapping images in the background to screen selector and adjust images from the list 

**Before:**
![old](https://github.com/hertg/lightdm-neon/assets/43760717/b2f7af37-02cb-44f7-8299-09908cbccabc)

**After:**
![new](https://github.com/hertg/lightdm-neon/assets/43760717/76e5e0b9-b144-4a17-9860-5f6649f55c5a)
